### PR TITLE
Environment Variables!

### DIFF
--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.h
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.h
@@ -32,6 +32,14 @@
  */
 @property (nonatomic, readonly) NSString *name;
 
+/**
+ *  The build environment variables, as reported by `xcodebuild -showBuildSettings`, as an NSDictionary suitable for
+ *  use as an NSTask's environment property.
+ *
+ *  Note that this runs `xcodebuild` synchronously, so it's probably a bad idea to call it on the main thread.
+ */
+@property (nonatomic, readonly) NSDictionary *environmentVariables;
+
 - (instancetype)initWithPbxProject:(id<VOK_PBXProject>)pbxProject;
 
 - (void)save;

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
@@ -118,6 +118,7 @@ static NSString *const PlistExtension = @"XcAB.plist";
 
 - (NSDictionary *)environmentVariables
 {
+    NSAssert(![NSThread isMainThread], @"VOKProjectContainer environmentVariables being retrieved on the main thread.");
     if ([NSThread isMainThread]) {
         NSLog(@"VOKProjectContainer environmentVariables being retrieved on the main thread.");
     }

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
@@ -159,9 +159,9 @@ static NSString *const PlistExtension = @"XcAB.plist";
          if (result.numberOfRanges != 3) {
              return;
          }
-         id key = [outputString substringWithRange:[result rangeAtIndex:1]];
-         id value = [outputString substringWithRange:[result rangeAtIndex:2]];
-         env[key] = value;
+         id variableName = [outputString substringWithRange:[result rangeAtIndex:1]];
+         id variableValue = [outputString substringWithRange:[result rangeAtIndex:2]];
+         env[variableName] = variableValue;
      }];
     return [env copy];
 }

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
@@ -136,6 +136,12 @@ static NSString *const PlistExtension = @"XcAB.plist";
     NSData *outputData = [outputPipe.fileHandleForReading readDataToEndOfFile];
     NSString *outputString = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
     
+    /*
+     *  The output of `xcodebuild -showBuildSettings` is primarily lines of the form
+     *      [whitespace][key][whitespace]=[whitespace][value]
+     *  so we'll use a regular expression to capture each key and value pair in this format, assuming that the key 
+     *  won't have any whitespace (shell variable names shouldn't).
+     */
     NSError *error;
     NSRegularExpression *regex = [NSRegularExpression
                                   regularExpressionWithPattern:
@@ -153,9 +159,11 @@ static NSString *const PlistExtension = @"XcAB.plist";
      options:NSMatchingReportProgress
      range:NSMakeRange(0, outputString.length)
      usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
-         // In `result`, the 0th range is the range of the string that matches the whole regex and the 1st and 2nd
-         // ranges are the 1st and 2nd capture groups (the key and value), so there should be 3 ranges in the result--
-         // if there aren't, something's borked.
+         /*
+          *  In `result`, the 0th range is the range of the string that matches the whole regex and the 1st and 2nd
+          *  ranges are the 1st and 2nd capture groups (the key and value), so there should be 3 ranges in the result--
+          *  if there aren't, something's borked.
+          */
          if (result.numberOfRanges != 3) {
              return;
          }

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKProjectContainer.m
@@ -153,6 +153,9 @@ static NSString *const PlistExtension = @"XcAB.plist";
      options:NSMatchingReportProgress
      range:NSMakeRange(0, outputString.length)
      usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
+         // In `result`, the 0th range is the range of the string that matches the whole regex and the 1st and 2nd
+         // ranges are the 1st and 2nd capture groups (the key and value), so there should be 3 ranges in the result--
+         // if there aren't, something's borked.
          if (result.numberOfRanges != 3) {
              return;
          }

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
@@ -159,6 +159,7 @@ static NSString *const ShouldRecurseKey = @"should_recurse";
             NSTask *task = [[NSTask alloc] init];
             task.launchPath = self.absolutePathToScript;
             task.currentDirectoryPath = [task.launchPath stringByDeletingLastPathComponent];
+            task.environment = self.containingProject.environmentVariables;
             [task launch];
         });
     } else {

--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
@@ -155,10 +155,12 @@ static NSString *const ShouldRecurseKey = @"should_recurse";
 {
     //Check if file is runnable or Xcode will crash
     if ([[NSFileManager defaultManager] isExecutableFileAtPath:self.absolutePathToScript]) {
-        NSTask *task = [[NSTask alloc] init];
-        task.launchPath = self.absolutePathToScript;
-        task.currentDirectoryPath = [task.launchPath stringByDeletingLastPathComponent];
-        [task launch];
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            NSTask *task = [[NSTask alloc] init];
+            task.launchPath = self.absolutePathToScript;
+            task.currentDirectoryPath = [task.launchPath stringByDeletingLastPathComponent];
+            [task launch];
+        });
     } else {
         NSAlert *alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:[VOKLocalizedStrings ok]];

--- a/XcodeAutoBasher/XcodeAutoBasher/XcodeAutoBasher-Info.plist
+++ b/XcodeAutoBasher/XcodeAutoBasher/XcodeAutoBasher-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Resolves #12.

This provides the running task with the environment variables as reported by `xcodebuild -showBuildVariables`.  Because that's run synchronously, the task-launching has been moved to a background thread.

I wasn't sure how best to express this in the README, especially since using the environment variables will make the advice about testing the script in Terminal very hard to follow.

@designatednerd Wanna review this or should I `@`-ping the whole team?