### PR TITLE
Relative path to the folder being watched sent as $1 argument to the script

### DIFF
--- a/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
+++ b/XcodeAutoBasher/XcodeAutoBasher/Models/VOKScriptForFolder.m
@@ -160,6 +160,7 @@ static NSString *const ShouldRecurseKey = @"should_recurse";
             task.launchPath = self.absolutePathToScript;
             task.currentDirectoryPath = [task.launchPath stringByDeletingLastPathComponent];
             task.environment = self.containingProject.environmentVariables;
+            task.arguments = @[self.pathToFolder];
             [task launch];
         });
     } else {


### PR DESCRIPTION
Hi, I made a very little enhancement, it make easier to use the relative path, to the folder that triggered the script, in order to navigate there.

Thanks for your project, hope it helps.